### PR TITLE
Require individual lodash functions.

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,4 +1,8 @@
-var _ = require('lodash')
+var _ = {
+  filter: require('lodash/filter'),
+  map: require('lodash/map'),
+  find: require('lodash/find')
+}
 var React = require('react')
 var DataFrame = require('dataframe')
 var Emitter = require('wildemitter')
@@ -215,7 +219,7 @@ module.exports = React.createClass({
 
     var columns = this.getColumns()
 
-    var csv = _.pluck(columns, 'title')
+    var csv = _.map(columns, 'title')
       .map(JSON.stringify.bind(JSON))
       .join(',') + '\n'
 

--- a/lib/column-control.jsx
+++ b/lib/column-control.jsx
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _ = { without: require('lodash/without') }
 var React = require('react')
 
 module.exports = React.createClass({

--- a/lib/dimensions.jsx
+++ b/lib/dimensions.jsx
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _ = { compact: require('lodash/compact') }
 var React = require('react')
 var partial = require('./partial')
 

--- a/lib/pivot-table.jsx
+++ b/lib/pivot-table.jsx
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _ = { range: require('lodash/range') }
 var React = require('react')
 var partial = require('./partial')
 var getValue = require('./get-value')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cssify": "^0.7.0",
     "dataframe": "^1.3.0",
     "envify": "^3.2.0",
-    "lodash": "^3.3.1",
+    "lodash": "^4.1.0",
     "react": ">=0.12.2",
     "reactify": "^1.0.0",
     "wildemitter": "^1.0.1",


### PR DESCRIPTION
To save kbs for a smaller footprint, only include lodash functions that are required.
Closes #35.