### PR TITLE
Use react ^0.14.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dataframe": "^1.3.0",
     "envify": "^3.2.0",
     "lodash": "^4.1.0",
-    "react": ">=0.12.2",
+    "react": "^0.14.8",
     "reactify": "^1.0.0",
     "wildemitter": "^1.0.1",
     "xtend": "^4.0.0"


### PR DESCRIPTION
It seems like when the node_modules directory is not yet created, running the ```npm install``` throws an error about peer dependencies, wanting react ^0.14.8