### PR TITLE
Fix hidden columns leaking between multiple pivot tables

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -211,8 +211,7 @@ module.exports = React.createClass({
   },
 
   hideColumn: function(cTitle) {
-    var hidden = this.state.hiddenColumns
-    hidden.push(cTitle)
+    var hidden = this.state.hiddenColumns.concat([cTitle])
     this.setHiddenColumns(hidden)
     setTimeout(this.updateRows, 0)
   },


### PR DESCRIPTION
The default `hiddenColumns` array is mutable, and shared between all pivot tables. This means that any hidden columns added to to this list (via `push`) are hidden on all pivot tables on the page that have not changed from the default.

To reproduce issue:

1. Create page that can contain a variable number of pivot tables.
2. Hide and then show a column in one of the tables.
3. Either add another table, or make a change in one of the other tables (such as adding a dimension) that does not change the hidden columns.
4. The affected table will now have a column hidden.