### PR TITLE
Ensure hidden columns are set on prop change

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -70,8 +70,9 @@ module.exports = React.createClass({
   },
 
   componentWillReceiveProps: function(newProps) {
-    newProps.hiddenColumns !== this.props.hiddenColumns &&
-      this.setHiddenColumns(newProps.hiddenColumns);
+     if(newProps.hiddenColumns !== this.props.hiddenColumns) {
+         this.setHiddenColumns(newProps.hiddenColumns);
+     }
 
     if(newProps.rows !== this.props.rows) {
       this.dataFrame = DataFrame({

--- a/index.jsx
+++ b/index.jsx
@@ -68,15 +68,18 @@ module.exports = React.createClass({
 
     this.updateRows()
   },
-  
+
   componentWillReceiveProps: function(newProps) {
+    newProps.hiddenColumns !== this.props.hiddenColumns &&
+      this.setHiddenColumns(newProps.hiddenColumns);
+
     if(newProps.rows !== this.props.rows) {
       this.dataFrame = DataFrame({
         rows: newProps.rows,
         dimensions: this.props.dimensions,
         reduce: this.props.reduce
       })
-      
+
       this.updateRows()
     }
   },


### PR DESCRIPTION
Currently when changes to the hidden columns props are made, the relevant functions to hide the newly passed columns are not called.