### PR TITLE
Remove deprecation warnings for future React versions

### DIFF
--- a/example/demo.jsx
+++ b/example/demo.jsx
@@ -2,6 +2,7 @@ require('./demo.css')
 
 var React = require('react')
 var ReactDOM = require('react-dom')
+var createReactClass = require('create-react-class')
 var ReactPivot = require('..')
 
 var gh = require('./gh.jsx')
@@ -51,7 +52,7 @@ var calculations = [
   }
 ]
 
-var Demo = React.createClass({
+var Demo = createReactClass({
   getInitialState: function() {
     return {showInput: false}
   },

--- a/index.jsx
+++ b/index.jsx
@@ -4,6 +4,7 @@ var _ = {
   find: require('lodash/find')
 }
 var React = require('react')
+var createReactClass = require('create-react-class')
 var DataFrame = require('dataframe')
 var Emitter = require('wildemitter')
 
@@ -14,7 +15,7 @@ var PivotTable = require('./lib/pivot-table.jsx')
 var Dimensions = require('./lib/dimensions.jsx')
 var ColumnControl = require('./lib/column-control.jsx')
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'ReactPivot',
   getDefaultProps: function() {
     return {

--- a/lib/column-control.jsx
+++ b/lib/column-control.jsx
@@ -1,7 +1,8 @@
 var _ = { without: require('lodash/without') }
 var React = require('react')
+var createReactClass = require('create-react-class')
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   getDefaultProps: function () {
     return {
       hiddenColumns: [],

--- a/lib/dimensions.jsx
+++ b/lib/dimensions.jsx
@@ -1,8 +1,9 @@
 var _ = { compact: require('lodash/compact') }
 var React = require('react')
+var createReactClass = require('create-react-class')
 var partial = require('./partial')
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   getDefaultProps: function () {
     return {
       dimensions: [],

--- a/lib/pivot-table.jsx
+++ b/lib/pivot-table.jsx
@@ -1,9 +1,10 @@
 var _ = { range: require('lodash/range') }
 var React = require('react')
+var createReactClass = require('create-react-class')
 var partial = require('./partial')
 var getValue = require('./get-value')
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   getDefaultProps: function () {
     return {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "url": "https://github.com/davidguttman/react-pivot/issues"
   },
   "dependencies": {
+    "create-react-class": "^15.6.0",
     "cssify": "^0.7.0",
     "dataframe": "^1.3.0",
     "envify": "^3.2.0",
     "lodash": "^4.1.0",
-    "react": ">=0.12.2",
+    "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "reactify": "^1.0.0",
     "wildemitter": "^1.0.1",


### PR DESCRIPTION
Accessing createClass via the main React package is deprecated, and will be removed in React v16.0.

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass