### PR TITLE
fix tableClassName injection

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -165,6 +165,7 @@ module.exports = createReactClass({
           onSort={this.setSort}
           onColumnHide={this.hideColumn}
           nPaginateRows={this.props.nPaginateRows}
+          tableClassName={this.props.tableClassName}
           onSolo={this.setSolo}
           soloText={this.props.soloText}
         />


### PR DESCRIPTION
tableClassName is being used inside render function of PivotTable, but it's not injected from react-pivot 