### PR TITLE
refactor: export download csv function as an object

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -9,7 +9,7 @@ var DataFrame = require('dataframe')
 var Emitter = require('wildemitter')
 
 var partial = require('./lib/partial')
-var download = require('./lib/download')
+var { download } = require('./lib/download')
 var getValue = require('./lib/get-value')
 var PivotTable = require('./lib/pivot-table.jsx')
 var Dimensions = require('./lib/dimensions.jsx')

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,4 +1,4 @@
-module.exports = function(content, filename, mime) {
+module.exports.download = function(content, filename, mime) {
   if (mime == null) mime = 'text/csv'
 
   var blob = new Blob([content], { type: mime })


### PR DESCRIPTION
## CONTEXT

This PR refactors the **download CSV function** to be exported as **an object**: { download: function (params) {code...} }. This will facilitate in unit testing when we want to stub the functionality of the download function.

In my scenario, we are using **Sinon** for stubbing and mocking. The **Sinon** method - [**sinon.stub(object, "method")**](https://sinonjs.org/releases/v14/stubs/) requires a root object and a property to stub on that object. Thus, we could not successfully stub the function since It is currently exported as a function not an object. 