### PR TITLE
Add clear filters button for clearing solo filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,23 @@ React.render(
 
 See it all together in [example/basic.jsx](https://github.com/davidguttman/react-pivot/blob/master/example/basic.jsx)
 
+### Solo Filters ###
+
+ReactPivot supports "solo" filtering, which allows users to click on values in the table to filter the data to only show rows matching that value. When solo filters are active, you can optionally display a "Clear Filters" button to remove all filters at once.
+
+```jsx
+<ReactPivot 
+  rows={rows}
+  dimensions={dimensions}
+  reduce={reduce}
+  calculations={calculations}
+  showClearFilters={true}
+  clearFiltersText="Reset Filters"
+/>
+```
+
+The `clearFiltersText` prop is optional and defaults to `"Clear Filters"`. When `showClearFilters` is set to `true`, a Clear button appears in the same toolbar row as the solo filter dropdown and Pause Filters whenever filters are active, allowing users to clear all filters with a single click.
+
 ### Optional Arguments ###
 parameter | type | description | default
 --------- | ---- | ----------- | -------
@@ -160,6 +177,8 @@ sortDir | string | sort direction, either 'asc' or 'desc' | 'asc'
 tableClassName | string | assign css class to table containing react-pivot elements | ''
 hideDimensionFilter | boolean | do not render the dimension filter | false
 hideRows | function | if provided, rows that are passed to the function will not render unless the return value is true | null
+showClearFilters | boolean | display Clear Filters button when solo filters are active | false
+clearFiltersText | string | customizable text for the clear filters button | 'Clear Filters'
 
 ### TODO ###
 

--- a/example/demo.jsx
+++ b/example/demo.jsx
@@ -148,7 +148,9 @@ var Demo = createReactClass({
                       eventBus={eventBus}
                       nPaginateRows={20}
                       soloText="🔍"
-                      unsoloText="↩️" />
+                      unsoloText="↩️"
+                      showClearFilters={true}
+                      clearFiltersText="Clear Filters" />
         </div>
 
         <div className={this.state.showInput ? '' : 'hide'}>

--- a/index.jsx
+++ b/index.jsx
@@ -45,7 +45,9 @@ export default createReactClass({
       onData: function () {},
       soloText: "solo",
       unsoloText: "unsolo",
-      subDimensionText: "Sub Dimension..."
+      subDimensionText: "Sub Dimension...",
+      showClearFilters: false,
+      clearFiltersText: "Clear Filters"
     }
   },
 
@@ -129,13 +131,26 @@ export default createReactClass({
     return columns
   },
 
-  renderFiltersToggle: function() {
-    if (soloEntries(this.state.solo).length === 0) return null
+  renderFilterActions: function() {
+    var hasFilters = soloEntries(this.state.solo).length > 0
+
+    if (!hasFilters) {
+      return <SoloControl solo={this.state.solo} onToggle={this.setSolo} />
+    }
 
     var buttonText = this.state.filtersPaused ? 'Resume Filters' : 'Pause Filters'
 
     return (
-      <div className='reactPivot-filtersToggle'>
+      <div className='reactPivot-filterActions'>
+        <SoloControl solo={this.state.solo} onToggle={this.setSolo} />
+        {this.props.showClearFilters && (
+          <button
+            className='reactPivot-clearFilters'
+            onClick={this.clearSolo}
+          >
+            {this.props.clearFiltersText}
+          </button>
+        )}
         <button onClick={this.toggleFilters}>
           {buttonText}
         </button>
@@ -161,12 +176,7 @@ export default createReactClass({
               hiddenColumns={this.state.hiddenColumns}
               onChange={this.setHiddenColumns} />
 
-            <SoloControl
-              solo={this.state.solo}
-              onToggle={this.setSolo}
-            />
-
-            {this.renderFiltersToggle()}
+            {this.renderFilterActions()}
 
             <div className="reactPivot-csvExport">
               <button onClick={partial(this.downloadCSV, this.state.rows)}>
@@ -277,6 +287,11 @@ export default createReactClass({
 
     // Auto-resume filters when adding or removing a solo value
     this.setState({solo: newSolo, filtersPaused: false}, this.updateRows)
+  },
+
+  clearSolo: function() {
+    this.props.eventBus.emit('solo', {})
+    this.setState({solo: {}, filtersPaused: false}, this.updateRows)
   },
 
   addSoloValue: function(valueMap, key) {
@@ -452,13 +467,14 @@ td:hover .reactPivot-solo {opacity: 0.5}
   flex-shrink: 0;
 }
 
-.reactPivot-filtersToggle {
+.reactPivot-filterActions {
   display: flex;
+  gap: 5px;
   align-items: flex-start;
   flex: 0 0 auto;
 }
 
-.reactPivot-filtersToggle button {
+.reactPivot-filterActions button {
   background-color: #FFF;
   border: 1px solid #CCC;
   height: 28px;
@@ -469,6 +485,12 @@ td:hover .reactPivot-solo {opacity: 0.5}
   margin-top: 0;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.reactPivot-soloControl {
+  display: flex;
+  gap: 5px;
+  align-items: flex-start;
 }
 
 .reactPivot-dimensions {


### PR DESCRIPTION
Closes #123 

- Add showClearFilters and clearFiltersText props to ReactPivot
- Implement clearSolo() and renderFilterActions() with Clear and Pause in one place
- SoloControl is dropdown-only; filter UI consolidated in ReactPivot
- Update demo and README with documentation and usage examples

Backward compatible; disabled by default.

Note that to test the feature, you need to first add solo filters, otherwise the "Clear Filters" button won't show.

**Demo:**
![clear-filters-demo](https://github.com/user-attachments/assets/4fbaebe1-31e0-46b4-b77f-415c6dadb5a4)
